### PR TITLE
お店情報の新規登録の実装

### DIFF
--- a/app/Http/Controllers/ShopsController.php
+++ b/app/Http/Controllers/ShopsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Shops;
+use App\Http\Requests\StoreShop;
 
 class ShopsController extends Controller
 {
@@ -29,6 +30,7 @@ class ShopsController extends Controller
     public function create()
     {
         //
+        return view('create_shop');
     }
 
     /**
@@ -37,9 +39,11 @@ class ShopsController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(StoreShop $request)
     {
         //
+        Shops::create($request->all());
+        return redirect()->route('shops.index')->with('success', '新規登録完了');
     }
 
     /**

--- a/app/Http/Requests/StoreShop.php
+++ b/app/Http/Requests/StoreShop.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreShop extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+            'name' => 'required',
+            'description' => 'required',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'name.required' => 'お店の名前を入力して下さい。',
+            'description.required' => 'お店の説明を入力して下さい。',
+        ];
+    }
+}

--- a/app/Models/Shops.php
+++ b/app/Models/Shops.php
@@ -9,4 +9,5 @@ class Shops extends Model
 {
     use HasFactory;
     protected $table = 'shops';
+    protected $fillable = ['name','description'];
 }

--- a/resources/views/create_shop.blade.php
+++ b/resources/views/create_shop.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+@section('title', 'create-shop')
+@section('content')
+  <h3>新規のお店を登録する</h3>
+  @if ($errors->any())
+    <ul>
+        @foreach ($errors->all() as $error)
+        <li>{{ $error }}</li>
+        @endforeach
+    </ul>
+    @endif
+  <form method="post" action="{{ route('shops.store')}}">
+  @csrf
+    <div class="form-group">
+      <label for="shopName">お店の名前</label>
+      <input type="text" name="name">
+    </div>
+    <div class="form-group">
+    <label for="descInput">説明文</label>
+    <textarea name="description"></textarea>
+    </div>
+    <button type="submit">新規追加</button>
+  </form>
+@endsection

--- a/resources/views/shop_list.blade.php
+++ b/resources/views/shop_list.blade.php
@@ -3,7 +3,12 @@
 @section('title', 'shop-page')
 @section('content')
 <main>
+    <p><a href="{{ route('shops.create') }}" class="btn btn-primary">新規のお店を登録する</a></p>
     <section style="text-align: center;">
+      @if ($message = Session::get('success'))
+            <p style="color: red;">{{ $message }}</p>
+      @endif
+
       @if($shop_list->isEmpty())
 
       <p>登録がありません</p>
@@ -18,5 +23,6 @@
           @endforeach
       @endif
     </section>
+    
 </main>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,7 @@ use App\Http\Controllers\TopPageController;
 Route::get('/', 'App\Http\Controllers\TopPageController@show');
 
 Route::resource('shops', 'App\Http\Controllers\ShopsController')->only([
-    'index','show' // このメソッドは有効
+    'index','show','create','store' // このメソッドは有効
 ]);
 
 Route::middleware(['auth:sanctum', 'verified'])->get('/dashboard', function () {


### PR DESCRIPTION
・お店一覧ページに新規登録ページに遷移するリンクを設定
・Shopsコントローラーのcreate、storeメソッドを有効化
・create.blade.phpに入力フォームを実装
・フォーム入力後にお店情報が作成され、お店一覧ページに遷移する
