### PR TITLE
マイページの実装・よく行くエリア設定と変更ページ作成

### DIFF
--- a/app/Http/Controllers/MypagesController.php
+++ b/app/Http/Controllers/MypagesController.php
@@ -12,26 +12,24 @@ class MypagesController extends Controller
     public function show($id)
     {
         $user = User::find($id);
-        $area_id = $user->area_id;
-        $area = Area::find($area_id);
         return view('mypage.show', compact('user'));
     }
 
     public function edit($id)
     {
         $user = User::find($id);
-        $area_id = $user->area_id;
-        $area = Area::find($area_id);
-        return view('mypage.change_area', compact('user','area'));
+        $area = $user->area;
+        $areas = Area::select('id','area_name')->get();
+        return view('mypage.edit', compact('user','area','areas'));
     }
 
     public function update(Request $request, $id)
     {
         $update = [
             'area_id' => $request->area_id,
+            'profile' => $request->profile,
         ];
         User::find($id)->update($update);
-        $user = User::find($id);
-        return redirect()->route('mypage.show',['mypage'=>$user->id])->with('success', '変更完了');
+        return redirect()->route('mypage.show',['mypage'=>$id])->with('success', '変更完了');
     }
 }

--- a/app/Http/Controllers/MypagesController.php
+++ b/app/Http/Controllers/MypagesController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\User;
+use App\Models\Area;
+
+class MypagesController extends Controller
+{
+    //
+    public function show($id)
+    {
+        $user = User::find($id);
+        $area_id = $user->area_id;
+        $area = Area::find($area_id);
+        return view('mypage.show', compact('user'));
+    }
+
+    public function edit($id)
+    {
+        $user = User::find($id);
+        $area_id = $user->area_id;
+        $area = Area::find($area_id);
+        return view('mypage.change_area', compact('user','area'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $update = [
+            'area_id' => $request->area_id,
+        ];
+        User::find($id)->update($update);
+        $user = User::find($id);
+        return redirect()->route('mypage.show',['mypage'=>$user->id])->with('success', '変更完了');
+    }
+}

--- a/app/Http/Controllers/TopPageController.php
+++ b/app/Http/Controllers/TopPageController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 
 class TopPageController extends Controller
 {
     //トップページを表示
     public function show(){
-        return view('top');
+        $user = Auth::id();
+        return view('top', compact('user'));
     }
 }

--- a/app/Http/Controllers/TopPageController.php
+++ b/app/Http/Controllers/TopPageController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 
 class TopPageController extends Controller

--- a/app/Models/Area.php
+++ b/app/Models/Area.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Area extends Model
+{
+    use HasFactory;
+    protected $table = 'areas';
+
+    public function users()
+    {
+        return $this->hasMany(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,6 +27,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'profile',
+        'area_id',
     ];
 
     /**
@@ -58,4 +60,9 @@ class User extends Authenticatable
     protected $appends = [
         'profile_photo_url',
     ];
+
+    public function area()
+    {
+        return $this->belongsTo(Area::class);
+    }
 }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,12 +16,14 @@ class CreateUsersTable extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('profile');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();
             $table->text('profile_photo_path')->nullable();
             $table->timestamps();
+            $table->foreignId('area_id');
         });
     }
 

--- a/database/migrations/2021_04_25_112927_create_areas_table.php
+++ b/database/migrations/2021_04_25_112927_create_areas_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAreasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('areas', function (Blueprint $table) {
+            $table->id();
+            $table->string('area_name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('areas');
+    }
+}

--- a/resources/views/mypage/change_area.blade.php
+++ b/resources/views/mypage/change_area.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+@section('title', 'change_area-page')
+@section('content')
+<form action="{{ route('mypage.update', $user->id)}}" method="POST">
+@csrf
+  @method('PUT')
+  @if($user->area_id == 0)
+    <div class="form-group">
+        <label>よく行くエリアの設定</label>
+        <select name="area_id">
+        <option value="1">表参道</option>
+        <option value="2">渋谷</option>
+        </select>
+    </div>
+    <input type="submit" value="登録する">
+  @else
+  <h3>{{ $user->name }}さんの設定エリア</h3>
+  <p>現在のエリア：{{ $area->area_name }} </p>
+  <p>↓</p>
+    <div class="form-group">
+        <label>変更後のエリア</label>
+        <select name="area_id">
+        <option value="1">表参道</option>
+        <option value="2">渋谷</option>
+        </select>
+    </div>
+    <input type="submit" value="更新する">
+    @endif
+</form>
+
+<a href="{{ url('/') }}">トップページに戻る</a>
+@endsection

--- a/resources/views/mypage/edit.blade.php
+++ b/resources/views/mypage/edit.blade.php
@@ -8,9 +8,14 @@
     <div class="form-group">
         <label>よく行くエリアの設定</label>
         <select name="area_id">
-        <option value="1">表参道</option>
-        <option value="2">渋谷</option>
+        @foreach ($areas as $value)
+          <option value="{{ $value->id }}">{{ $value->area_name }}</option>
+        @endforeach
         </select>
+    </div>
+    <div class="form-group">
+        <label>プロフィールの登録</label><br>
+        <textarea name="profile" placeholder="プロフィール文を入力してください"></textarea>
     </div>
     <input type="submit" value="登録する">
   @else
@@ -24,6 +29,10 @@
           <option value="{{ $value->id }}">{{ $value->area_name }}</option>
         @endforeach
         </select>
+    </div>
+    <div class="form-group">
+        <label>プロフィール</label><br>
+        <textarea name="profile">{{ $user->profile }}</textarea>
     </div>
     <input type="submit" value="更新する">
     @endif

--- a/resources/views/mypage/edit.blade.php
+++ b/resources/views/mypage/edit.blade.php
@@ -20,8 +20,9 @@
     <div class="form-group">
         <label>変更後のエリア</label>
         <select name="area_id">
-        <option value="1">表参道</option>
-        <option value="2">渋谷</option>
+        @foreach ($areas as $value)
+          <option value="{{ $value->id }}">{{ $value->area_name }}</option>
+        @endforeach
         </select>
     </div>
     <input type="submit" value="更新する">

--- a/resources/views/mypage/show.blade.php
+++ b/resources/views/mypage/show.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.app')
+
+@section('title', 'my-page')
+
+@section('content')
+<h3>こんにちは{{ $user->name }}さん</h3>
+  @if($user->area_id == 0)
+
+    <p>エリア未登録です <a href="{{  route('mypage.edit',$user->id) }}">登録はこちら</a></p>  
+  @else
+  <p>よく行くエリア：{{ $user->area->area_name }} <a href="{{  route('mypage.edit',$user->id) }}">エリアを変更する</a></p>
+  @endif
+<a href="{{ url('/') }}">トップページに戻る</a>
+
+@endsection
+
+<main>
+</main>

--- a/resources/views/mypage/show.blade.php
+++ b/resources/views/mypage/show.blade.php
@@ -8,7 +8,7 @@
 
     <p>エリア未登録です <a href="{{  route('mypage.edit',$user->id) }}">登録はこちら</a></p>  
   @else
-  <p>よく行くエリア：{{ $user->area->area_name }} <a href="{{  route('mypage.edit',$user->id) }}">エリアを変更する</a></p>
+  <p>よく行くエリア：{{ $user->area->area_name }} <a href="{{  route('mypage.edit',$user->id) }}">エリアを変更する(プロフォール編集)</a></p>
   @endif
 <a href="{{ url('/') }}">トップページに戻る</a>
 

--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -5,7 +5,7 @@
 @section('nav')
 
   @auth
-    <a href="{{ url('/') }}">mypage</a>
+    <a href="{{ route('mypage.show',['mypage'=>$user])}}">mypage</a>
     <form method="POST" action="{{ route('logout') }}">
       @csrf
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,3 +23,9 @@ Route::resource('shops.review', 'App\Http\Controllers\ReviewsController');
 Route::middleware(['auth:sanctum', 'verified'])->get('/dashboard', function () {
     return view('dashboard');
 })->name('dashboard');
+
+Route::middleware('auth')->group(function () {
+    Route::view('mypage', 'mypage.show')->name('mypage');
+});
+
+Route::resource('mypage', 'App\Http\Controllers\MypagesController',['only' => ['show', 'edit', 'update']]); 

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,8 +24,4 @@ Route::middleware(['auth:sanctum', 'verified'])->get('/dashboard', function () {
     return view('dashboard');
 })->name('dashboard');
 
-Route::middleware('auth')->group(function () {
-    Route::view('mypage', 'mypage.show')->name('mypage');
-});
-
 Route::resource('mypage', 'App\Http\Controllers\MypagesController',['only' => ['show', 'edit', 'update']]); 


### PR DESCRIPTION
・ログイン後のトップページにマイページに遷移するリンクを設定
・マイページでは、エリアが未登録・登録済のユーザーで画面の表示を分けている。
・エリア登録済のユーザー画面では、現在の登録エリア名を表示・変更画面へのリンクを設定
・エリア未登録のユーザー画面では、エリア登録画面へのリンクを設定