### PR TITLE
テスト実装(バリデーションエラーパターン)

### DIFF
--- a/app/Http/Requests/StoreReview.php
+++ b/app/Http/Requests/StoreReview.php
@@ -25,7 +25,7 @@ class StoreReview extends FormRequest
     {
         return [
             'title' => 'required|max:14',
-            'comment' => 'required',
+            'comment' => 'required|max:200',
             'image.*' => 'image|file|mimes:jpg,png',
         ];
     }
@@ -36,6 +36,7 @@ class StoreReview extends FormRequest
             'title.required' => 'タイトルを入力して下さい。',
             'title.max' => 'タイトルは14文字以内で入力してください',
             'comment.required' => 'レビューを入力して下さい。',
+            'comment.max' => '文字数オーバーです！コメントは200文字以内で入力してください',
             'image.*.image' => '画像を添付してください',
             'image.*.mimes' => '画像はjpgかpngのみです'
         ];

--- a/tests/Unit/Requests/StoreImageTest.php
+++ b/tests/Unit/Requests/StoreImageTest.php
@@ -14,43 +14,34 @@ class StoreImageTest extends TestCase
      * A basic unit test example.
      *
      * @return void
+     * @dataProvider additionProvider
      */
-    public function testStoreImage()
+    public function testStoreImage(array $data, bool $expect)
     {
-        Storage::fake('image');
-        $file = UploadedFile::fake()->image('shop_image.jpg');
-
-        $image = ['image' => $file];
-
+        $data_list = $data;
+        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
         $request = new StoreImage();
         $rules = $request->rules();
-        $validator = Validator::make($image, $rules);
+        $validator = Validator::make($data_list, $rules);
         $result = $validator->passes();
-        $this->assertTrue($result);
+        $this->assertEquals($expect, $result);
     }
 
-    public function testErrorImageInBlank()
+    public function additionProvider()
     {
-        $image = ['image' => ''];
-
-        $request = new StoreImage();
-        $rules = $request->rules();
-        $validator = Validator::make($image, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
-
-    public function testErrorImageEndOfFileName()
-    {
-        Storage::fake('image');
-        $file = UploadedFile::fake()->image('shop_image.txt');
-
-        $image = ['image' => $file];
-
-        $request = new StoreImage();
-        $rules = $request->rules();
-        $validator = Validator::make($image, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
+        return [
+            'OK' => [
+                ['image' => UploadedFile::fake()->create('dummy.png')], 
+                true
+            ],
+            'ファイルが添付されていない' => [
+                ['image' => null],
+                false
+            ],
+            '画像の拡張子が違う' => [
+                ['image' => UploadedFile::fake()->create('dummy.txt')],
+                false
+            ],
+        ];
     }
 }

--- a/tests/Unit/Requests/StoreImageTest.php
+++ b/tests/Unit/Requests/StoreImageTest.php
@@ -28,4 +28,29 @@ class StoreImageTest extends TestCase
         $result = $validator->passes();
         $this->assertTrue($result);
     }
+
+    public function test_store_image_error_in_blank()
+    {
+        $image = ['image' => ''];
+
+        $request = new StoreImage();
+        $rules = $request->rules();
+        $validator = Validator::make($image, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_image_error_end_of_file_name()
+    {
+        Storage::fake('image');
+        $file = UploadedFile::fake()->image('shop_image.txt');
+
+        $image = ['image' => $file];
+
+        $request = new StoreImage();
+        $rules = $request->rules();
+        $validator = Validator::make($image, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
 }

--- a/tests/Unit/Requests/StoreImageTest.php
+++ b/tests/Unit/Requests/StoreImageTest.php
@@ -19,7 +19,7 @@ class StoreImageTest extends TestCase
     public function testStoreImage(array $data, bool $expect)
     {
         $data_list = $data;
-        $data_list = array_merge($data_list, array('image' => UploadedFile::fake()->create('dummy.jpg')));
+        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
         $request = new StoreImage();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);

--- a/tests/Unit/Requests/StoreImageTest.php
+++ b/tests/Unit/Requests/StoreImageTest.php
@@ -19,7 +19,7 @@ class StoreImageTest extends TestCase
     public function testStoreImage(array $data, bool $expect)
     {
         $data_list = $data;
-        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
+        $data_list = array_merge($data_list, array('image' => UploadedFile::fake()->create('dummy.jpg')));
         $request = new StoreImage();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);

--- a/tests/Unit/Requests/StoreImageTest.php
+++ b/tests/Unit/Requests/StoreImageTest.php
@@ -15,7 +15,7 @@ class StoreImageTest extends TestCase
      *
      * @return void
      */
-    public function test_store_image()
+    public function testStoreImage()
     {
         Storage::fake('image');
         $file = UploadedFile::fake()->image('shop_image.jpg');
@@ -29,7 +29,7 @@ class StoreImageTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function test_store_image_error_in_blank()
+    public function testErrorImageInBlank()
     {
         $image = ['image' => ''];
 
@@ -40,7 +40,7 @@ class StoreImageTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function test_store_image_error_end_of_file_name()
+    public function testErrorImageEndOfFileName()
     {
         Storage::fake('image');
         $file = UploadedFile::fake()->image('shop_image.txt');

--- a/tests/Unit/Requests/StoreImageTest.php
+++ b/tests/Unit/Requests/StoreImageTest.php
@@ -16,13 +16,12 @@ class StoreImageTest extends TestCase
      * @return void
      * @dataProvider additionProvider
      */
-    public function testStoreImage(array $data, bool $expect)
+    public function testStoreImage($key, $value, bool $expect)
     {
-        $data_list = $data;
-        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
+        $data = [$key => $value];
         $request = new StoreImage();
         $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
+        $validator = Validator::make($data, $rules);
         $result = $validator->passes();
         $this->assertEquals($expect, $result);
     }
@@ -30,18 +29,9 @@ class StoreImageTest extends TestCase
     public function additionProvider()
     {
         return [
-            'OK' => [
-                ['image' => UploadedFile::fake()->create('dummy.png')], 
-                true
-            ],
-            'ファイルが添付されていない' => [
-                ['image' => null],
-                false
-            ],
-            '画像の拡張子が違う' => [
-                ['image' => UploadedFile::fake()->create('dummy.txt')],
-                false
-            ],
+            'OK' => ['image', UploadedFile::fake()->create('dummy.png'), true],
+            'ファイルが添付されていない' => ['image', null, false],
+            '画像の拡張子が違う' => ['image', UploadedFile::fake()->create('dummy.txt'), false],
         ];
     }
 }

--- a/tests/Unit/Requests/StorePhotoTest.php
+++ b/tests/Unit/Requests/StorePhotoTest.php
@@ -18,7 +18,7 @@ class StorePhotoTest extends TestCase
     public function testStorePhoto(array $data, bool $expect)
     {
         $data_list = $data;
-        $data_list = array_merge($data_list, array('image' => UploadedFile::fake()->create('dummy.jpg')));
+        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
         $request = new StorePhoto();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);

--- a/tests/Unit/Requests/StorePhotoTest.php
+++ b/tests/Unit/Requests/StorePhotoTest.php
@@ -15,7 +15,7 @@ class StorePhotoTest extends TestCase
      *
      * @return void
      */
-    public function test_store_photo()
+    public function testStorePhoto()
     {
         Storage::fake('image');
         $file = UploadedFile::fake()->image('review_image.jpg');
@@ -29,7 +29,7 @@ class StorePhotoTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function test_store_photo_error_in_blank()
+    public function testErrorPhotoInBlank()
     {
         $image = ['image' => ''];
 
@@ -40,7 +40,7 @@ class StorePhotoTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function test_store_photo_error_end_of_file_name()
+    public function testErrorPhotoEndOfFileName()
     {
         Storage::fake('image');
         $file = UploadedFile::fake()->image('review_image.txt');

--- a/tests/Unit/Requests/StorePhotoTest.php
+++ b/tests/Unit/Requests/StorePhotoTest.php
@@ -15,13 +15,12 @@ class StorePhotoTest extends TestCase
      * @return void
      * @dataProvider additionProvider
      */
-    public function testStorePhoto(array $data, bool $expect)
+    public function testStorePhoto($key, $value, bool $expect)
     {
-        $data_list = $data;
-        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
+        $data = [$key => $value];
         $request = new StorePhoto();
         $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
+        $validator = Validator::make($data, $rules);
         $result = $validator->passes();
         $this->assertEquals($expect, $result);
     }
@@ -29,18 +28,9 @@ class StorePhotoTest extends TestCase
     public function additionProvider()
     {
         return [
-            'OK' => [
-                ['image' => UploadedFile::fake()->create('dummy.png')], 
-                true
-            ],
-            'ファイルが添付されていない' => [
-                ['image' => null],
-                false
-            ],
-            '画像の拡張子が違う' => [
-                ['image' => UploadedFile::fake()->create('dummy.txt')],
-                false
-            ],
+            'OK' => ['image', UploadedFile::fake()->create('dummy.png'), true],
+            'ファイルが添付されていない' => ['image', null, false],
+            '画像の拡張子が違う' => ['image', UploadedFile::fake()->create('dummy.txt'), false],
         ];
     }
 }

--- a/tests/Unit/Requests/StorePhotoTest.php
+++ b/tests/Unit/Requests/StorePhotoTest.php
@@ -28,4 +28,29 @@ class StorePhotoTest extends TestCase
         $result = $validator->passes();
         $this->assertTrue($result);
     }
+
+    public function test_store_photo_error_in_blank()
+    {
+        $image = ['image' => ''];
+
+        $request = new StorePhoto();
+        $rules = $request->rules();
+        $validator = Validator::make($image, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_photo_error_end_of_file_name()
+    {
+        Storage::fake('image');
+        $file = UploadedFile::fake()->image('review_image.txt');
+
+        $image = ['image' => $file];
+
+        $request = new StorePhoto();
+        $rules = $request->rules();
+        $validator = Validator::make($image, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
 }

--- a/tests/Unit/Requests/StorePhotoTest.php
+++ b/tests/Unit/Requests/StorePhotoTest.php
@@ -18,7 +18,7 @@ class StorePhotoTest extends TestCase
     public function testStorePhoto(array $data, bool $expect)
     {
         $data_list = $data;
-        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
+        $data_list = array_merge($data_list, array('image' => UploadedFile::fake()->create('dummy.jpg')));
         $request = new StorePhoto();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);

--- a/tests/Unit/Requests/StoreReviewTest.php
+++ b/tests/Unit/Requests/StoreReviewTest.php
@@ -19,7 +19,6 @@ class StoreReviewTest extends TestCase
     public function testStoreReview(array $keys, array $values, bool $expect)
     {
         $data_list = array_combine($keys, $values);
-        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
         $request = new StoreReview();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);
@@ -32,7 +31,7 @@ class StoreReviewTest extends TestCase
         return [
             'OK' => [
                 ['title', 'comment', 'image'],
-                ['タイトル', 'レビューコメント', ['*' => UploadedFile::fake()->create('dummy.png')]],
+                ['タイトル', 'レビューコメント', [UploadedFile::fake()->create('dummy.png')]],
                 true
             ],
             'お店の名前が空白' => [
@@ -57,7 +56,7 @@ class StoreReviewTest extends TestCase
             ],
             '画像の拡張子が違う' => [
                 ['title', 'comment', 'image'],
-                ['タイトル', 'レビューコメント', ['*' => UploadedFile::fake()->create('dummy.txt')]],
+                ['タイトル', 'レビューコメント', [UploadedFile::fake()->create('dummy.txt')]],
                 false
             ],
         ];

--- a/tests/Unit/Requests/StoreReviewTest.php
+++ b/tests/Unit/Requests/StoreReviewTest.php
@@ -18,7 +18,7 @@ class StoreReviewTest extends TestCase
 
     public function testStoreReview(array $keys, array $values, bool $expect)
     {
-        $data_list = array_combine($keys, $values);
+        $data_list = [$keys => $values];
         $request = new StoreReview();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);

--- a/tests/Unit/Requests/StoreReviewTest.php
+++ b/tests/Unit/Requests/StoreReviewTest.php
@@ -14,93 +14,48 @@ class StoreReviewTest extends TestCase
     /**
      * A basic feature test example.
      *
-     * @return void
+     * @dataProvider additionProvider
      */
-    public function test_store_review()
-    {
-        Storage::fake('image');
-        $file = UploadedFile::fake()->image('review_image.jpg');
 
-        $data_list = [
-            'title' => 'タイトル',
-            'comment' => 'レビューコメント',
-            'image.*' => $file,
+    public function testStoreReview(array $keys, array $values, bool $expect)
+    {
+        $dataList = array_combine($keys, $values);
+        $request = new StoreReview();
+        $rules = $request->rules();
+        $validator = Validator::make($dataList, $rules);
+        $result = $validator->passes();
+        $this->assertEquals($expect, $result);
+    }
+
+    public function additionProvider()
+    {
+        return [
+            'OK' => [
+                ['title', 'comment'],
+                ['タイトル', 'レビューコメント'],
+                true
+            ],
+            'お店の名前が空白' => [
+                ['title', 'comment'],
+                [null, 'レビューコメント'],
+                false
+            ],
+            'お店の説明文が空白' => [
+                ['title', 'comment'],
+                ['タイトル', null],
+                false
+            ],
+            'お店の名前が文字数超過' => [
+                ['title', 'comment'],
+                [str_repeat('a', 15), 'レビューコメント'],
+                false
+            ],
+            'お店の説明文が文字数超過' => [
+                ['title', 'comment'],
+                ['タイトル', str_repeat('a', 201)],
+                false
+            ],
         ];
-
-        $request = new StoreReview();
-        $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
-        $result = $validator->passes();
-        $this->assertTrue($result);
     }
-
-    public function test_store_review_error_title_in_blank()
-    {
-        $data_list = [
-            'title' => '',
-            'comment' => 'レビューコメント'
-        ];
-
-        $request = new StoreReview();
-        $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
-
-    public function test_store_review_error_comment_in_blank()
-    {
-        $data_list = [
-            'title' => 'タイトル',
-            'comment' => ''
-        ];
-
-        $request = new StoreReview();
-        $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
-
-    public function test_store_error_title_too_many_charactors()
-    {
-        $data_list = [
-            'title' => 'タイトルを14文字以上入力するとエラーになるテストです',
-            'comment' => 'レビューコメント'
-        ];
-
-        $request = new StoreReview();
-        $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
-
-    public function test_store_error_comment_too_many_charactors()
-    {
-        $data_list = [
-            'title' => 'タイトル',
-            'comment' => str_repeat('a', 201)
-        ];
-
-        $request = new StoreReview();
-        $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
-
-    public function test_store_error_image_end_of_file_name()
-    {
-        Storage::fake('image');
-        $file = UploadedFile::fake()->image('review_image.txt');
-
-        $image = ['image.*' => $file];
-
-        $request = new StoreReview();
-        $rules = $request->rules();
-        $validator = Validator::make($image, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
+    
 }

--- a/tests/Unit/Requests/StoreReviewTest.php
+++ b/tests/Unit/Requests/StoreReviewTest.php
@@ -7,7 +7,6 @@ use Tests\TestCase;
 use Illuminate\Support\Facades\Validator;
 use App\Http\Requests\StoreReview;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 
 class StoreReviewTest extends TestCase
 {
@@ -20,6 +19,7 @@ class StoreReviewTest extends TestCase
     public function testStoreReview(array $keys, array $values, bool $expect)
     {
         $data_list = array_combine($keys, $values);
+        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
         $request = new StoreReview();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);
@@ -31,8 +31,8 @@ class StoreReviewTest extends TestCase
     {
         return [
             'OK' => [
-                ['title', 'comment'],
-                ['タイトル', 'レビューコメント'],
+                ['title', 'comment', 'image'],
+                ['タイトル', 'レビューコメント', ['*' => UploadedFile::fake()->create('dummy.png')]],
                 true
             ],
             'お店の名前が空白' => [
@@ -53,6 +53,11 @@ class StoreReviewTest extends TestCase
             'お店の説明文が文字数超過' => [
                 ['title', 'comment'],
                 ['タイトル', str_repeat('a', 201)],
+                false
+            ],
+            '画像の拡張子が違う' => [
+                ['title', 'comment', 'image'],
+                ['タイトル', 'レビューコメント', ['*' => UploadedFile::fake()->create('dummy.txt')]],
                 false
             ],
         ];

--- a/tests/Unit/Requests/StoreReviewTest.php
+++ b/tests/Unit/Requests/StoreReviewTest.php
@@ -19,10 +19,10 @@ class StoreReviewTest extends TestCase
 
     public function testStoreReview(array $keys, array $values, bool $expect)
     {
-        $dataList = array_combine($keys, $values);
+        $data_list = array_combine($keys, $values);
         $request = new StoreReview();
         $rules = $request->rules();
-        $validator = Validator::make($dataList, $rules);
+        $validator = Validator::make($data_list, $rules);
         $result = $validator->passes();
         $this->assertEquals($expect, $result);
     }

--- a/tests/Unit/Requests/StoreReviewTest.php
+++ b/tests/Unit/Requests/StoreReviewTest.php
@@ -18,7 +18,7 @@ class StoreReviewTest extends TestCase
 
     public function testStoreReview(array $keys, array $values, bool $expect)
     {
-        $data_list = [$keys => $values];
+        $data_list = array_combine($keys, $values);
         $request = new StoreReview();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);

--- a/tests/Unit/Requests/StoreReviewTest.php
+++ b/tests/Unit/Requests/StoreReviewTest.php
@@ -33,4 +33,74 @@ class StoreReviewTest extends TestCase
         $result = $validator->passes();
         $this->assertTrue($result);
     }
+
+    public function test_store_review_error_title_in_blank()
+    {
+        $data_list = [
+            'title' => '',
+            'comment' => 'レビューコメント'
+        ];
+
+        $request = new StoreReview();
+        $rules = $request->rules();
+        $validator = Validator::make($data_list, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_review_error_comment_in_blank()
+    {
+        $data_list = [
+            'title' => 'タイトル',
+            'comment' => ''
+        ];
+
+        $request = new StoreReview();
+        $rules = $request->rules();
+        $validator = Validator::make($data_list, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_error_title_too_many_charactors()
+    {
+        $data_list = [
+            'title' => 'タイトルを14文字以上入力するとエラーになるテストです',
+            'comment' => 'レビューコメント'
+        ];
+
+        $request = new StoreReview();
+        $rules = $request->rules();
+        $validator = Validator::make($data_list, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_error_comment_too_many_charactors()
+    {
+        $data_list = [
+            'title' => 'タイトル',
+            'comment' => str_repeat('a', 201)
+        ];
+
+        $request = new StoreReview();
+        $rules = $request->rules();
+        $validator = Validator::make($data_list, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_error_image_end_of_file_name()
+    {
+        Storage::fake('image');
+        $file = UploadedFile::fake()->image('review_image.txt');
+
+        $image = ['image.*' => $file];
+
+        $request = new StoreReview();
+        $rules = $request->rules();
+        $validator = Validator::make($image, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
 }

--- a/tests/Unit/Requests/StoreReviewTest.php
+++ b/tests/Unit/Requests/StoreReviewTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit\Requests;
 
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Validator;
 use App\Http\Requests\StoreReview;

--- a/tests/Unit/Requests/StoreShopTest.php
+++ b/tests/Unit/Requests/StoreShopTest.php
@@ -13,93 +13,52 @@ class StoreShopTest extends TestCase
     /**
      * A basic unit test example.
      *
-     * @return void
+     * @dataProvider additionProvider
      */
-    public function test_store_shop()
+
+    public function testStoreShop(array $keys, array $values, bool $expect)
     {
-        Storage::fake('image');
-        $file = UploadedFile::fake()->image('shop_image.jpg');
-
-        $data_list = [
-            'name' => 'お店の名前',
-            'description' => '説明文',
-            'image.*' => $file,
-        ];
-
+        $dataList = array_combine($keys, $values);
         $request = new StoreShop();
         $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
+        $validator = Validator::make($dataList, $rules);
         $result = $validator->passes();
-        $this->assertTrue($result);
+        $this->assertEquals($expect, $result);
     }
 
-    public function test_store_error_shop_name_in_blank()
+    public function additionProvider()
     {
-        $data_list = [
-            'name' => '',
-            'description' => '説明文'
+        return [
+            'OK' => [
+                ['name', 'description'],
+                ['お店の名前', '説明文'],
+                true
+            ],
+            'お店の名前が空白' => [
+                ['name', 'description'],
+                [null, '説明文'],
+                false
+            ],
+            'お店の説明文が空白' => [
+                ['name', 'description'],
+                ['お店の名前', null],
+                false
+            ],
+            'お店の名前が文字数超過' => [
+                ['name', 'description'],
+                [str_repeat('a', 11), '説明文'],
+                false
+            ],
+            'お店の説明文が文字数超過' => [
+                ['name', 'description'],
+                ['お店の名前', str_repeat('a', 101)],
+                false
+            ],
+            '画像の拡張子が違う' => [
+                ['name', 'description', 'image.*'],
+                ['お店の名前', '説明文', UploadedFile::fake()->image('shop_image.text')],
+                false
+            ],
         ];
-
-        $request = new StoreShop();
-        $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
-
-    public function test_store_error_shop_description_in_blank()
-    {
-        $data_list = [
-            'name' => 'お店の名前',
-            'description' => ''
-        ];
-
-        $request = new StoreShop();
-        $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
-
-    public function test_store_error_shop_name_too_many_charactors()
-    {
-        $data_list = [
-            'name' => 'お店の名前を10文字以上入力するとエラーになるテスト',
-            'description' => '説明文',
-        ];
-
-        $request = new StoreShop();
-        $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
-
-    public function test_store_error_shop_description_too_many_charactors()
-    {
-        $data_list = [
-            'name' => 'お店の名前',
-            'description' => str_repeat('a', 101),
-        ];
-
-        $request = new StoreShop();
-        $rules = $request->rules();
-        $validator = Validator::make($data_list, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
-    }
-
-    public function test_store_error_image_end_of_file_name()
-    {
-        Storage::fake('image');
-        $file = UploadedFile::fake()->image('shop_image.txt');
-
-        $image = ['image.*' => $file];
-
-        $request = new StoreShop();
-        $rules = $request->rules();
-        $validator = Validator::make($image, $rules);
-        $result = $validator->passes();
-        $this->assertFalse($result);
     }
 }

--- a/tests/Unit/Requests/StoreShopTest.php
+++ b/tests/Unit/Requests/StoreShopTest.php
@@ -18,7 +18,10 @@ class StoreShopTest extends TestCase
 
     public function testStoreShop(array $keys, array $values, bool $expect)
     {
+        Storage::fake('image');
+        $file = UploadedFile::fake()->image('shop_image.jpg');
         $data_list = array_combine($keys, $values);
+        $data_list = array_merge($data_list, array('image.*' => $file));
         $request = new StoreShop();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);
@@ -57,7 +60,7 @@ class StoreShopTest extends TestCase
             '画像の拡張子が違う' => [
                 ['name', 'description', 'image.*'],
                 ['お店の名前', '説明文', UploadedFile::fake()->image('shop_image.text')],
-                false
+                true
             ],
         ];
     }

--- a/tests/Unit/Requests/StoreShopTest.php
+++ b/tests/Unit/Requests/StoreShopTest.php
@@ -18,10 +18,10 @@ class StoreShopTest extends TestCase
 
     public function testStoreShop(array $keys, array $values, bool $expect)
     {
-        $dataList = array_combine($keys, $values);
+        $data_list = array_combine($keys, $values);
         $request = new StoreShop();
         $rules = $request->rules();
-        $validator = Validator::make($dataList, $rules);
+        $validator = Validator::make($data_list, $rules);
         $result = $validator->passes();
         $this->assertEquals($expect, $result);
     }

--- a/tests/Unit/Requests/StoreShopTest.php
+++ b/tests/Unit/Requests/StoreShopTest.php
@@ -6,7 +6,6 @@ use Tests\TestCase;
 use Illuminate\Support\Facades\Validator;
 use App\Http\Requests\StoreShop;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 
 class StoreShopTest extends TestCase
 {
@@ -18,10 +17,8 @@ class StoreShopTest extends TestCase
 
     public function testStoreShop(array $keys, array $values, bool $expect)
     {
-        Storage::fake('image');
-        $file = UploadedFile::fake()->image('shop_image.jpg');
         $data_list = array_combine($keys, $values);
-        $data_list = array_merge($data_list, array('image.*' => $file));
+        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
         $request = new StoreShop();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);
@@ -33,8 +30,8 @@ class StoreShopTest extends TestCase
     {
         return [
             'OK' => [
-                ['name', 'description'],
-                ['お店の名前', '説明文'],
+                ['name', 'description', 'image'],
+                ['お店の名前', '説明文', ['*' => UploadedFile::fake()->create('dummy.png')]],
                 true
             ],
             'お店の名前が空白' => [
@@ -58,9 +55,9 @@ class StoreShopTest extends TestCase
                 false
             ],
             '画像の拡張子が違う' => [
-                ['name', 'description', 'image.*'],
-                ['お店の名前', '説明文', UploadedFile::fake()->image('shop_image.text')],
-                true
+                ['name', 'description', 'image'],
+                ['お店の名前', '説明文', ['*' => UploadedFile::fake()->create('dummy.txt')]],
+                false
             ],
         ];
     }

--- a/tests/Unit/Requests/StoreShopTest.php
+++ b/tests/Unit/Requests/StoreShopTest.php
@@ -17,7 +17,7 @@ class StoreShopTest extends TestCase
 
     public function testStoreShop(array $keys, array $values, bool $expect)
     {
-        $data_list = array_combine($keys, $values);
+        $data_list = [$keys => $values];
         $request = new StoreShop();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);

--- a/tests/Unit/Requests/StoreShopTest.php
+++ b/tests/Unit/Requests/StoreShopTest.php
@@ -32,4 +32,74 @@ class StoreShopTest extends TestCase
         $result = $validator->passes();
         $this->assertTrue($result);
     }
+
+    public function test_store_error_shop_name_in_blank()
+    {
+        $data_list = [
+            'name' => '',
+            'description' => '説明文'
+        ];
+
+        $request = new StoreShop();
+        $rules = $request->rules();
+        $validator = Validator::make($data_list, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_error_shop_description_in_blank()
+    {
+        $data_list = [
+            'name' => 'お店の名前',
+            'description' => ''
+        ];
+
+        $request = new StoreShop();
+        $rules = $request->rules();
+        $validator = Validator::make($data_list, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_error_shop_name_too_many_charactors()
+    {
+        $data_list = [
+            'name' => 'お店の名前を10文字以上入力するとエラーになるテスト',
+            'description' => '説明文',
+        ];
+
+        $request = new StoreShop();
+        $rules = $request->rules();
+        $validator = Validator::make($data_list, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_error_shop_description_too_many_charactors()
+    {
+        $data_list = [
+            'name' => 'お店の名前',
+            'description' => str_repeat('a', 101),
+        ];
+
+        $request = new StoreShop();
+        $rules = $request->rules();
+        $validator = Validator::make($data_list, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
+
+    public function test_store_error_image_end_of_file_name()
+    {
+        Storage::fake('image');
+        $file = UploadedFile::fake()->image('shop_image.txt');
+
+        $image = ['image.*' => $file];
+
+        $request = new StoreShop();
+        $rules = $request->rules();
+        $validator = Validator::make($image, $rules);
+        $result = $validator->passes();
+        $this->assertFalse($result);
+    }
 }

--- a/tests/Unit/Requests/StoreShopTest.php
+++ b/tests/Unit/Requests/StoreShopTest.php
@@ -18,7 +18,6 @@ class StoreShopTest extends TestCase
     public function testStoreShop(array $keys, array $values, bool $expect)
     {
         $data_list = array_combine($keys, $values);
-        $data_list = array_merge($data_list, array('image[]' => ['*' => UploadedFile::fake()->create('dummy.jpg')]));
         $request = new StoreShop();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);
@@ -31,7 +30,7 @@ class StoreShopTest extends TestCase
         return [
             'OK' => [
                 ['name', 'description', 'image'],
-                ['お店の名前', '説明文', ['*' => UploadedFile::fake()->create('dummy.png')]],
+                ['お店の名前', '説明文', [UploadedFile::fake()->create('dummy.png')]],
                 true
             ],
             'お店の名前が空白' => [
@@ -56,7 +55,7 @@ class StoreShopTest extends TestCase
             ],
             '画像の拡張子が違う' => [
                 ['name', 'description', 'image'],
-                ['お店の名前', '説明文', ['*' => UploadedFile::fake()->create('dummy.txt')]],
+                ['お店の名前', '説明文', [UploadedFile::fake()->create('dummy.txt')]],
                 false
             ],
         ];

--- a/tests/Unit/Requests/StoreShopTest.php
+++ b/tests/Unit/Requests/StoreShopTest.php
@@ -17,7 +17,7 @@ class StoreShopTest extends TestCase
 
     public function testStoreShop(array $keys, array $values, bool $expect)
     {
-        $data_list = [$keys => $values];
+        $data_list = array_combine($keys, $values);
         $request = new StoreShop();
         $rules = $request->rules();
         $validator = Validator::make($data_list, $rules);


### PR DESCRIPTION
フォーム入力で、必要項目が空白・文字数オーバー、画像の拡張子がpng,jpg以外の際に
assertFalseとなるか

対象：以下バリデーションテストファイル

・StoreshopTest.php
・StoreReviewTest.php
・StoreImageTest.php
・StorePhotoTest.php